### PR TITLE
documentEditable class

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- Template: add documentEditable class to the inner div#dashboard, since the outer div
+  is usually removed by diazo based themes.
+  [jone]
+
 - Add dashboard-columns-X class on manage-dashboard view too.
   [jone]
 

--- a/ftw/dashboard/dragndrop/browser/templates/dashboard.pt
+++ b/ftw/dashboard/dragndrop/browser/templates/dashboard.pt
@@ -84,8 +84,9 @@
             </dl>
 
             <div id="dashboard"
-                 tal:define="column_amount python:context.portal_properties.get('ftw.dashboard') and context.portal_properties.get('ftw.dashboard').columnNumber or 4;"
-                 tal:attributes="class string:dashboard-columns-${column_amount}">
+                 tal:define="column_amount python:context.portal_properties.get('ftw.dashboard') and context.portal_properties.get('ftw.dashboard').columnNumber or 4;
+                             classes python:editable and 'documentEditable' or '';"
+                 tal:attributes="class string:dashboard-columns-${column_amount} ${classes}">
                 <div tal:condition="editable" id="dashboard-add-portlet" tal:define="referer python:context.absolute_url()+'/'+ view.__name__;">
                     <form tal:attributes="action python:context.portal_url()">
                         <textarea style="display:none" tal:content="referer" rows="" cols="" name="referer"></textarea>

--- a/ftw/dashboard/dragndrop/browser/templates/manage-dashboard.pt
+++ b/ftw/dashboard/dragndrop/browser/templates/manage-dashboard.pt
@@ -84,7 +84,7 @@
 
                         <div id="dashboard"
                              tal:define="column_amount python:context.portal_properties.get('ftw.dashboard') and context.portal_properties.get('ftw.dashboard').columnNumber or 4"
-                             tal:attributes="class string:dashboard-columns-${column_amount}">
+                             tal:attributes="class string:documentEditable dashboard-columns-${column_amount}">
                             <div id="dashboard-add-portlet" tal:define="referer python:context.absolute_url()+'/'+ view.__name__;">
                                 <form tal:attributes="action python:context.portal_url()">
                                     <textarea style="display:none" tal:content="referer" rows="" cols="" name="referer"></textarea>


### PR DESCRIPTION
Template: add documentEditable class to the inner div#dashboard, since the
outer div is usually removed by diazo based themes.

@maethu is this a good idea?
