### PR TITLE
Align add portlet form in IE and Chrome

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- Added a nbsp to make sure the add portlet form is aligned right in IE and Chrome.
+  [Julian Infanger]
+
 - Update dashboard column height when draging a portlet.
   [Julian Infanger]
 

--- a/ftw/dashboard/dragndrop/browser/templates/dashboard.pt
+++ b/ftw/dashboard/dragndrop/browser/templates/dashboard.pt
@@ -88,6 +88,7 @@
                  tal:attributes="class string:dashboard-columns-${column_amount}">
                 <div tal:condition="editable" id="dashboard-add-portlet" tal:define="referer python:context.absolute_url()+'/'+ view.__name__;">
                     <form tal:attributes="action python:context.portal_url()">
+                      &nbsp;
                         <textarea style="display:none" tal:content="referer" rows="" cols="" name="referer"></textarea>
                         <select name=":action"
                             tal:define="dashboard_props python: getattr(context.portal_properties,'ftw.dashboard', None);"

--- a/ftw/dashboard/dragndrop/browser/templates/manage-dashboard.pt
+++ b/ftw/dashboard/dragndrop/browser/templates/manage-dashboard.pt
@@ -87,6 +87,7 @@
                              tal:attributes="class string:dashboard-columns-${column_amount}">
                             <div id="dashboard-add-portlet" tal:define="referer python:context.absolute_url()+'/'+ view.__name__;">
                                 <form tal:attributes="action python:context.portal_url()">
+                                  &nbsp;
                                     <textarea style="display:none" tal:content="referer" rows="" cols="" name="referer"></textarea>
                                     <select name=":action"
                                             tal:define="dashboard_props python: getattr(context.portal_properties,'ftw.dashboard', None);"


### PR DESCRIPTION
Added a nbsp to make sure the add portlet form is aligned right in IE and Chrome.
