### PR TITLE
fix the calendarwidget

### DIFF
--- a/ftw/dashboard/dragndrop/browser/resources/dashboard.css
+++ b/ftw/dashboard/dragndrop/browser/resources/dashboard.css
@@ -135,7 +135,8 @@ body.section-konto div#portal-column-two {
 }
 
 /* Remove dashboard dialog */
-.ui-widget-header {
+.template-dashboard .ui-widget-header,
+.template-manage-dashboard .ui-widget-header{
   display:none;
 }
 #remove-portlet-dialog {


### PR DESCRIPTION
@jone @maethu Can you take a look at this? We need this to get the calendarwidget working again. The way the CSS Selector were before it would hide the Month and Year selection
