### PR TITLE
Fixed accessibility issues in dashboard overview.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.5.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed accessibility issues in dashboard overview.
+  [Julian Infanger]
 
 
 1.5.1 (2013-01-29)

--- a/ftw/dashboard/dragndrop/browser/templates/dashboard.pt
+++ b/ftw/dashboard/dragndrop/browser/templates/dashboard.pt
@@ -74,8 +74,10 @@ tal:attributes="id string:regio-content;
                              tal:attributes="class string:dashboard-columns-${column_amount}">
                             <div tal:condition="editable" id="dashboard-add-portlet" tal:define="referer python:context.absolute_url()+'/'+ view.__name__;">
                                 <form tal:attributes="action python:context.portal_url()">
-                                    <textarea style="display:none" tal:content="referer" rows="" cols="" name="referer"></textarea>
+                                    <textarea style="display:none" tal:content="referer" title="referer" name="referer"></textarea>
                                     <select name=":action"
+                                            title="choose Portlet"
+                                            i18n:attributes="title"
                                             tal:define="dashboard_props python: getattr(context.portal_properties,'ftw.dashboard', None);"
                                             tal:condition="dashboard_props">
                                         <option value=""><tal:block i18n:translate="">choose Portlet</tal:block></option>

--- a/ftw/dashboard/dragndrop/browser/templates/manage-dashboard.pt
+++ b/ftw/dashboard/dragndrop/browser/templates/manage-dashboard.pt
@@ -87,8 +87,10 @@
                              tal:attributes="class string:dashboard-columns-${column_amount}">
                             <div id="dashboard-add-portlet" tal:define="referer python:context.absolute_url()+'/'+ view.__name__;">
                                 <form tal:attributes="action python:context.portal_url()">
-                                    <textarea style="display:none" tal:content="referer" rows="" cols="" name="referer"></textarea>
+                                    <textarea style="display:none" tal:content="referer" title="referer" name="referer"></textarea>
                                     <select name=":action"
+                                            title="choose Portlet"
+                                            i18n:attributes="title"
                                             tal:define="dashboard_props python: getattr(context.portal_properties,'ftw.dashboard', None);"
                                             tal:condition="dashboard_props">
                                         <option value=""><tal:block i18n:translate="">choose Portlet</tal:block></option>


### PR DESCRIPTION
- textarea (referer) should not have empty cols and rows attributes
- fields without label should have a title attribute (referer, add_portlet)
