### PR TITLE
Use better CSS selectors.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use better CSS selectors.
+  [Julian Infanger]
 
 
 1.5.2 (2013-04-16)

--- a/ftw/dashboard/dragndrop/browser/resources/dashboard.css
+++ b/ftw/dashboard/dragndrop/browser/resources/dashboard.css
@@ -20,7 +20,7 @@
     padding-right:1em;
     padding-left:1em;
 }
-.portletHeader {
+#dashboard .portletHeader {
     cursor: move;
 }
 


### PR DESCRIPTION
Only portletHeaders inside the dashboard are dragable, so there is no need to use `cursor: pointer` for all portletHeaders.
