### PR TITLE
Full with dialog

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.5.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Change width of delete portlet confirmation dialog
+  in order to make it easier customizable with css.
+  [Kevin Bieri]
 
 
 1.5.4 (2014-05-26)

--- a/ftw/dashboard/dragndrop/browser/resources/dnd_dashboard.js
+++ b/ftw/dashboard/dragndrop/browser/resources/dnd_dashboard.js
@@ -162,15 +162,10 @@ jQuery(function($){
     e.preventDefault();
     var wrapper = $(this).parents('.portletwrapper:first');
     var hash = wrapper.attr('id').substr('portletwrapper-'.length);
-    var pos = ($('#visual-portal-wrappers').width() / 2) - 150;
-    // fallback if there is no element visual-portal-wrapper
-    if ($('#visual-portal-wrappers').length === 0) {
-      pos = ($('body').width() / 2) - 150;
-    }
     $('<div></div>').
       html('<div id="remove-portlet-dialog">'+$('#text-remove-portlet').html()+'</div>').
       dialog({
-        modal: true, resizable: false, position:[pos, 100],
+        modal: true, resizable: false, position: {my: "center", at: "top+200"}, width: 1200,
         buttons: [
           {
             text: $("#text-remove-portlet-yes").html(),


### PR DESCRIPTION
As in https://git.4teamwork.ch/bern/bern.intranet/issues/95 seen the dialog does not match the standard ones from bern.intranet. So we decided to change the dialog width in this package for all installations which make use of this package.

It looks like this now:
![portlet delete dialog](https://cloud.githubusercontent.com/assets/28220/6778903/3ac94390-d157-11e4-9167-8f340b8b27d0.png)
