### PR TITLE
Fix edit button css class name.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix edit button css class name. [mathias.leimgruber]
 
 
 1.7.0 (2020-03-09)

--- a/ftw/dashboard/dragndrop/browser/resources/dnd_dashboard.js
+++ b/ftw/dashboard/dragndrop/browser/resources/dnd_dashboard.js
@@ -78,7 +78,7 @@ jQuery(function($){
 
           // edit link must be fixed: the column id may be wrong!
           // test if there is a edit link
-          var editLinks = $('#portletwrapper-' + newHash + ' .edit');
+          var editLinks = $('#portletwrapper-' + newHash + ' .buttonEdit');
           if(editLinks.length>0) {
             var editLink = editLinks[0];
             var href = editLink.getAttribute("href").replace(oldHash, newHash);


### PR DESCRIPTION
Otherwise the id does not receive a updated portlet-info-hash, which results in a false edit link.

Thus the portlet was not editable after moving it to a different column. 